### PR TITLE
wns: an option object can optionnaly be passed to wns lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ wns.send({
   {string} channelURI URI for the device to send the notification to
   {string} payload the XML string containing the notif data
   {string} type notif type. One of: toast, badge, tile, raw
+  {object} options an optional options object passed to wns lib (see wns lib)
 ```
 
 #### Events

--- a/lib/protocols/wns.js
+++ b/lib/protocols/wns.js
@@ -40,6 +40,7 @@ util.inherits(Sender, EventEmitter);
  * @param {string} data.channelURI
  * @param {string} data.payload
  * @param {string} data.type
+ * @param {string} data.options
  */
 
 Sender.prototype.send = function (data) {
@@ -55,11 +56,14 @@ Sender.prototype.send = function (data) {
   if (! _.contains(validTypes, data.type))
     return sender.emit('error', 'type should be one of: toast, badge, raw, tile');
 
-  //send
-  wns.send(data.channelURI, data.payload, 'wns/' + data.type, {
+  //create send options
+  var options = _.defaults({}, {
     client_id: data.client_id,
     client_secret: data.client_secret
-  },
+  }, data.options);
+
+  //send
+  wns.send(data.channelURI, data.payload, 'wns/' + data.type, options,
   //called once done of is there was a transmission error
   function (err, res) {
     if (err) return sender.emit('transmissionError', err, data.channelURI);

--- a/lib/protocols/wns.js
+++ b/lib/protocols/wns.js
@@ -57,7 +57,7 @@ Sender.prototype.send = function (data) {
     return sender.emit('error', 'type should be one of: toast, badge, raw, tile');
 
   //create send options
-  var options = _.defaults({}, {
+  var options = _.defaults({
     client_id: data.client_id,
     client_secret: data.client_secret
   }, data.options);

--- a/lib/protocols/wns.js
+++ b/lib/protocols/wns.js
@@ -40,7 +40,7 @@ util.inherits(Sender, EventEmitter);
  * @param {string} data.channelURI
  * @param {string} data.payload
  * @param {string} data.type
- * @param {string} data.options
+ * @param {object} data.options
  */
 
 Sender.prototype.send = function (data) {

--- a/test/unit/protocols/wns.js
+++ b/test/unit/protocols/wns.js
@@ -35,6 +35,28 @@ describe('WNS', function () {
       });
     });
 
+    it('should create a notification with options and send it', function () {
+      wnsSender.send({
+        channelURI: 'URI',
+        payload: 'XML',
+        type: 'raw',
+        options: {
+          headers: {
+            'Content-Type': 'application/octet-stream'
+          }
+        }
+      });
+
+      expect(wns.send).to.be.calledWith('URI', 'XML', 'wns/raw', {
+        client_id: 'foo',
+        client_secret: 'bar',
+        headers: {
+          'Content-Type': 'application/octet-stream'
+        }
+      });
+
+    });
+
     it('should emit an error for each missing required property', function () {
       var sender = notify.wns({
       });


### PR DESCRIPTION
For some notifications, options need to be set.
For example, to send a notification of type 'raw' the 'Content-Type' must be set to 'application/octet-stream'
